### PR TITLE
Splitted BaseAPIConnector into the two single responsibility classes classes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ django==2.2.2
 django-allauth==0.44.0
 django-rest-auth==0.9.5
 django-environ~=0.4.5
-pyyaml
+pyyaml~=5.4.1
 
 django-encrypted-model-fields~=0.5.8
 
@@ -18,3 +18,5 @@ python-gitlab ~= 2.7.1
 # Bitbucket-API
 bitbucket-api ~= 0.5.0
 atlassian-python-api ~= 3.10.0
+
+giturlparse~=0.10.0

--- a/swag_auth/api_connector.py
+++ b/swag_auth/api_connector.py
@@ -1,11 +1,14 @@
 import json
+import os
+from abc import ABC, abstractmethod
+from typing import Union
 
 import yaml
 from giturlparse import parse
 from rest_framework.exceptions import ValidationError
 
 
-class BaseAPIConnector:
+class BaseGitAPIConnector(ABC):
     def __init__(self, token):
         self._token = token
 
@@ -13,21 +16,8 @@ class BaseAPIConnector:
     def from_credentials(cls, credentials):
         return cls(credentials.token)
 
-    def get_swagger(self, url: str) -> dict:
-        owner, repo_name, branch, path = self._parse_url(url)
-
-        if not self.validate(path):
-            raise ValidationError("File content type must be JSON, YAML or YML")
-
-        repo = self.get_user_repo(repo_name=f'{owner}/{repo_name}')
-        contents = self.get_swagger_content(repo=repo, path=path, ref=branch)
-        if path.endswith('json'):
-            result = json.loads(contents)
-        else:
-            result = yaml.safe_load(contents)
-        return result
-
-    def get_swagger_content(self, repo, path, ref=None):
+    @abstractmethod
+    def get_file_content(self, repo, path, ref=None):
         """
         Return content of the given path file
         :param repo:
@@ -35,15 +25,16 @@ class BaseAPIConnector:
         :param ref:
         :return:
         """
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def get_user_repo(self, repo_name):
         """
         Return user`s repository
         :param repo_name:
         :return:
         """
-        raise NotImplementedError
+        pass
 
     def _parse_url(self, url: str) -> tuple:
         """
@@ -62,13 +53,39 @@ class BaseAPIConnector:
         else:
             branch = p.path.split('/', 1)[0]
             path = p.path.replace(f"{branch}/", '')
+
         return owner, repo_name, branch, path
 
-    def validate(self, path: str) -> bool:
+
+class BaseGitSwaggerDownloader(BaseGitAPIConnector, ABC):
+    # A mapping of extension name to a real loader
+    loaders = {
+        'json': json.loads,
+        'yml': yaml.safe_load,
+        'yaml': yaml.safe_load
+    }
+
+    def get_swagger_data(self, path: str, contents: Union[str, bytes]):
+        extension = os.path.splitext(path)[1][1:]
+
+        return self.loaders[extension](contents)
+
+    def get_swagger(self, url: str) -> dict:
+        owner, repo_name, branch, path = self._parse_url(url)
+
+        if not self.is_path_valid(path):
+            raise ValidationError("File content type must be JSON, YAML or YML")
+
+        repo = self.get_user_repo(repo_name=f'{owner}/{repo_name}')
+        contents = self.get_file_content(repo=repo, path=path, ref=branch)
+
+        return self.get_swagger_data(path, contents)
+
+    def is_path_valid(self, path: str) -> bool:
         """
         Validate path to YAML or JSON
         :param path:
         :return: bool:
         """
-        path = path.lower()
-        return path.endswith('json') or path.endswith('yml') or path.endswith('yaml')
+        extension = os.path.splitext(path)[1][1:]
+        return extension in self.loaders

--- a/swag_auth/github/connectors.py
+++ b/swag_auth/github/connectors.py
@@ -1,16 +1,17 @@
 from django.conf import settings
 from github import Github
 
-from swag_auth.api_connector import BaseAPIConnector
+from swag_auth.api_connector import BaseGitSwaggerDownloader
 from swag_auth.oauth2.views import CustomOAuth2Adapter
 
 
-class GithubAPIConnector(BaseAPIConnector):
+class GithubSwaggerDownloader(BaseGitSwaggerDownloader):
     def __init__(self, token):
-        super(GithubAPIConnector, self).__init__(token)
+        super().__init__(token)
+
         self.client = Github(self._token)
 
-    def get_swagger_content(self, repo, path, ref=None):
+    def get_file_content(self, repo, path, ref=None):
         """
         Return content of the given path file
         :param repo:
@@ -44,7 +45,7 @@ class GithubConnector(CustomOAuth2Adapter):
     emails_url = "https://api.github.com/user/emails"
     scope = settings.SWAGAUTH_SETTINGS['github']['SCOPE']
 
-    api_connector_class = GithubAPIConnector
+    api_connector_class = GithubSwaggerDownloader
 
 
 connector_classes = [GithubConnector]

--- a/swag_auth/gitlab/connectors.py
+++ b/swag_auth/gitlab/connectors.py
@@ -1,16 +1,17 @@
 from django.conf import settings
 from gitlab import Gitlab
 
-from swag_auth.api_connector import BaseAPIConnector
+from swag_auth.api_connector import BaseGitSwaggerDownloader
 from swag_auth.oauth2.views import CustomOAuth2Adapter
 
 
-class GitlabAPIConnector(BaseAPIConnector):
+class GitlabSwaggerDownloader(BaseGitSwaggerDownloader):
     def __init__(self, token):
-        super(GitlabAPIConnector, self).__init__(token)
+        super().__init__(token)
+
         self.client = Gitlab("https://gitlab.com", oauth_token=self._token)
 
-    def get_swagger_content(self, repo, path, ref=None):
+    def get_file_content(self, repo, path, ref=None):
         """
         Return content of the given path file
         :param repo:
@@ -43,7 +44,7 @@ class GitlabConnector(CustomOAuth2Adapter):
     secret = settings.SWAGAUTH_SETTINGS[provider_id]['APP']['secret']
     scope = settings.SWAGAUTH_SETTINGS[provider_id]['SCOPE']
 
-    api_connector_class = GitlabAPIConnector
+    api_connector_class = GitlabSwaggerDownloader
 
 
 connector_classes = [GitlabConnector]

--- a/swag_auth/models.py
+++ b/swag_auth/models.py
@@ -4,7 +4,7 @@ from django.utils.translation import gettext_lazy as _
 from encrypted_model_fields.fields import EncryptedTextField
 
 import swag_auth.registry as registry
-from swag_auth.api_connector import BaseAPIConnector
+from swag_auth.api_connector import BaseGitSwaggerDownloader
 
 
 class ConnectorToken(models.Model):
@@ -30,7 +30,7 @@ class ConnectorToken(models.Model):
     def __str__(self):
         return self.token
 
-    def get_api_connector(self) -> 'BaseAPIConnector':
+    def get_api_connector(self) -> 'BaseGitSwaggerDownloader':
         """Return an initialized instance of API connector for the particular connector."""
         provider = registry.connector_registry.by_id(self.connector)
 


### PR DESCRIPTION
BaseGitAPIConnector, which is an interface for interaction with git sources and `BaseGitSwaggerDownloader` which is an interface for downloading swagger only.